### PR TITLE
Upgrade to glimmer-dsl-libui 0.11.5 / Remove inverse-translation hack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "glimmer-dsl-libui", "= 0.11.4"
+gem "glimmer-dsl-libui", "= 0.11.5"
 gem "sidekiq"
 gem "chronic_duration", ">= 0.10.6", "< 2.0.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     glimmer (2.7.3)
       array_include_methods (~> 1.4.0)
       facets (>= 3.1.0, < 4.0.0)
-    glimmer-dsl-libui (0.11.4)
+    glimmer-dsl-libui (0.11.5)
       chunky_png (~> 1.4.0)
       color (~> 1.8)
       equalizer (= 0.0.11)
@@ -118,7 +118,7 @@ PLATFORMS
 
 DEPENDENCIES
   chronic_duration (>= 0.10.6, < 2.0.0)
-  glimmer-dsl-libui (= 0.11.4)
+  glimmer-dsl-libui (= 0.11.5)
   minitest
   rake
   sidekiq

--- a/kuiq.gemspec
+++ b/kuiq.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "glimmer-dsl-libui", "= 0.11.4"
+  spec.add_dependency "glimmer-dsl-libui", "= 0.11.5"
   spec.add_dependency "sidekiq", "~> 7.2"
   spec.add_dependency "chronic_duration", ">= 0.10.6", "< 2.0.0"
 end

--- a/lib/kuiq/model/job.rb
+++ b/lib/kuiq/model/job.rb
@@ -46,18 +46,12 @@ module Kuiq
 
       def respond_to_missing?(method_name, include_private = false)
         super ||
-          redis_hash.include?(it(method_name.to_s.capitalize).downcase) ||
           redis_hash.include?(method_name.to_s)
       end
 
       def method_missing(method_name, *args, &block)
-        inverse_translated_method_name = it(method_name.to_s.capitalize).underscore
         if redis_hash.include?(method_name.to_s)
           redis_hash[method_name.to_s].to_s
-        elsif respond_to?(inverse_translated_method_name) && !redis_hash.include?(inverse_translated_method_name)
-          send(inverse_translated_method_name)
-        elsif redis_hash.include?(inverse_translated_method_name)
-          redis_hash[inverse_translated_method_name].to_s
         else
           super
         end

--- a/lib/kuiq/view/morgue.rb
+++ b/lib/kuiq/view/morgue.rb
@@ -21,7 +21,15 @@ module Kuiq
             text_column(t("Arguments"))
             text_column(t("Error"))
 
-            cell_rows job_manager.dead_jobs
+            cell_rows <= [job_manager, :dead_jobs,
+                           column_attributes: {
+                             t("When") => :when,
+                             t("Queue") => :queue,
+                             t("Job") => :job,
+                             t("Arguments") => :arguments,
+                             t("Error") => :error,
+                           }
+                         ]
           }
 
           horizontal_separator {

--- a/lib/kuiq/view/retries_table.rb
+++ b/lib/kuiq/view/retries_table.rb
@@ -14,7 +14,16 @@ module Kuiq
           text_column(t("Arguments"))
           text_column(t("Error"))
 
-          cell_rows job_manager.retried_jobs
+          cell_rows <= [job_manager, :retried_jobs,
+                         column_attributes: {
+                           t("NextRetry") => :next_retry,
+                           t("RetryCount") => :retry_count,
+                           t("Queue") => :queue,
+                           t("Job") => :job,
+                           t("Arguments") => :arguments,
+                           t("Error") => :error,
+                         }
+                       ]
         }
       }
     end

--- a/lib/kuiq/view/scheduled_table.rb
+++ b/lib/kuiq/view/scheduled_table.rb
@@ -12,7 +12,15 @@ module Kuiq
           text_column(t("Job"))
           text_column(t("Arguments"))
 
-          cell_rows job_manager.scheduled_jobs
+          cell_rows <= [job_manager, :scheduled_jobs,
+                         column_attributes: {
+                           t("When") => :when,
+                           t("Queue") => :queue,
+                           t("Job") => :job,
+                           t("Arguments") => :arguments,
+                         }
+                       ]
+          
         }
       }
     end


### PR DESCRIPTION
I have good news. I updated glimmer-dsl-libui to support `Enumerator` with table explicit data-binding using `<=` or `<=>`, releasing version 0.11.5. Afterwards, I upgraded the version of glimmer-dsl-libui in Kuiq and then removed the inverse-translation hack by using the `column_attributes` table data-binding option. That worked well with all 3 tables (Retries, Scheduled, and Dead). The code is a lot more straight-forward now. This should fully address your concern in https://github.com/mperham/kuiq/issues/5