### PR TITLE
Dashboard graph grid lines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "glimmer-dsl-libui", "= 0.11.5"
+gem "glimmer-dsl-libui", "= 0.11.6"
 gem "sidekiq"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     glimmer (2.7.3)
       array_include_methods (~> 1.4.0)
       facets (>= 3.1.0, < 4.0.0)
-    glimmer-dsl-libui (0.11.5)
+    glimmer-dsl-libui (0.11.6)
       chunky_png (~> 1.4.0)
       color (~> 1.8)
       equalizer (= 0.0.11)
@@ -27,7 +27,7 @@ GEM
       rouge (>= 3.26.0, < 4.0.0)
       super_module (~> 1.4.1)
       text-table (>= 1.2.4, < 2.0.0)
-    json (2.6.3)
+    json (2.7.0)
     language_server-protocol (3.17.0.3)
     libui (0.1.2.pre)
     libui (0.1.2.pre-arm64-darwin)
@@ -114,7 +114,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  glimmer-dsl-libui (= 0.11.5)
+  glimmer-dsl-libui (= 0.11.6)
   minitest
   rake
   sidekiq

--- a/lib/kuiq.rb
+++ b/lib/kuiq.rb
@@ -10,9 +10,16 @@ module Kuiq
   GRAPH_PADDING_HEIGHT = 5.0
   GRAPH_PADDING_WIDTH = 5.0
   GRAPH_POINT_DISTANCE = 15.0
-  GRAPH_MAX_POINTS = (GRAPH_WIDTH / GRAPH_POINT_DISTANCE).to_i + 2
+  GRAPH_MAX_POINTS = (GRAPH_WIDTH / GRAPH_POINT_DISTANCE).to_i + 1
   GRAPH_DASHBOARD_COLORS = {
     processed: [47, 109, 104],
     failed: [163, 40, 39],
+    grid: [185, 184, 185],
+    marker: [204, 203, 203],
+    marker_dotted_line: [217, 217, 217],
+    marker_text: [96, 96, 96],
   }
+  POLLING_INTERVAL_MIN = 1
+  POLLING_INTERVAL_MAX = 20
+  POLLING_INTERVAL_DEFAULT = 2
 end

--- a/lib/kuiq/model/job_manager.rb
+++ b/lib/kuiq/model/job_manager.rb
@@ -10,7 +10,7 @@ module Kuiq
       attr_reader :redis_url, :redis_info, :current_time
 
       def initialize
-        @polling_interval = 1
+        @polling_interval = POLLING_INTERVAL_DEFAULT
         @redis_url = Sidekiq.redis { |c| c.config.server_url }
         @redis_info = Sidekiq.default_configuration.redis_info
         @current_time = Time.now.utc

--- a/lib/kuiq/view/dashboard.rb
+++ b/lib/kuiq/view/dashboard.rb
@@ -38,7 +38,7 @@ module Kuiq
                     }
                   }
 
-                  slider(1, 10) {
+                  slider(POLLING_INTERVAL_MIN, POLLING_INTERVAL_MAX) {
                     value <=> [job_manager, :polling_interval]
                   }
                 }

--- a/lib/kuiq/view/dashboard_graph.rb
+++ b/lib/kuiq/view/dashboard_graph.rb
@@ -19,7 +19,6 @@ module Kuiq
         time_remaining = job_manager.polling_interval
         timer_interval = 1 # 1 second
         Glimmer::LibUI.timer(timer_interval) do
-          presenter.record_stats
           if polling_interval != job_manager.polling_interval
             if job_manager.polling_interval < polling_interval
               time_remaining = job_manager.polling_interval
@@ -30,6 +29,7 @@ module Kuiq
           end
           time_remaining -= timer_interval
           if time_remaining == 0
+            presenter.record_stats
             job_manager.refresh
             body_root.queue_redraw_all
             time_remaining = job_manager.polling_interval
@@ -46,6 +46,7 @@ module Kuiq
           }
 
           on_draw do
+            grid_lines
             job_status_graph(:failed)
             job_status_graph(:processed)
           end
@@ -54,9 +55,41 @@ module Kuiq
       
       private
       
+      def grid_lines
+        line(GRAPH_PADDING_WIDTH, GRAPH_PADDING_HEIGHT, GRAPH_PADDING_WIDTH, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
+          stroke GRAPH_DASHBOARD_COLORS[:grid]
+        }
+        line(GRAPH_PADDING_WIDTH, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT, GRAPH_WIDTH - GRAPH_PADDING_WIDTH, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
+          stroke GRAPH_DASHBOARD_COLORS[:grid]
+        }
+        grid_marker_points = presenter.grid_marker_points
+        grid_marker_points.each_with_index do |marker_point, index|
+          grid_marker_number_value = grid_marker_points.size - index
+          grid_marker_number = grid_marker_number_value.to_s
+          thick = index != grid_marker_points.size - 1
+          line(marker_point.first, marker_point.last, marker_point.first + 4, marker_point.last) {
+            stroke *GRAPH_DASHBOARD_COLORS[:marker], thickness: thick ? 2 : 1
+          }
+          if grid_marker_number_value % 2 == 1 && grid_marker_number_value != grid_marker_points.size
+            line(marker_point.first, marker_point.last, marker_point.first + GRAPH_WIDTH - GRAPH_PADDING_WIDTH, marker_point.last) {
+              stroke *GRAPH_DASHBOARD_COLORS[:marker_dotted_line], thickness: 1, dashes: [1, 1]
+            }
+          end
+          if grid_marker_number_value % 2 == 1
+            text(marker_point.first + 4 + 3, marker_point.last - 6, 20) {
+              string(grid_marker_number) {
+                font family: 'Arial', size: 11
+                color GRAPH_DASHBOARD_COLORS[:marker_text]
+              }
+            }
+          end
+        end
+      end
+      
       def job_status_graph(job_status)
         last_point = nil
-        presenter.report_points(job_status).each do |point|
+        points = presenter.report_points(job_status)
+        points.each do |point|
           if last_point
             line(last_point.first, last_point.last, point.first, point.last) {
               stroke(*GRAPH_DASHBOARD_COLORS[job_status], thickness: 2)


### PR DESCRIPTION
I added Dashboard graph grid lines, which auto-adjust depending on the max height of the currently visible data stats.

![kuiq-dashboard-graph-grid-lines2](https://github.com/mperham/kuiq/assets/23052/2bc26169-72ab-4049-a80f-311fa82faf8b)

The only thing remaining to add to the Dashboard graph now is the hover effect that shows the hovered-over line & time/processed/failed values.