### PR TITLE
Dashboard graph hover displays time/failed/processed stats

### DIFF
--- a/lib/kuiq.rb
+++ b/lib/kuiq.rb
@@ -4,9 +4,11 @@ require "kuiq/version"
 
 module Kuiq
   WINDOW_WIDTH = 900.0
-  WINDOW_HEIGHT = 500.0
+  WINDOW_HEIGHT = 530.0
   GRAPH_WIDTH = 885.0
   GRAPH_HEIGHT = 200.0
+  GRAPH_STATUS_HEIGHT = 30.0
+  GRAPH_TEXT_WIDTH = 200.0
   GRAPH_PADDING_HEIGHT = 5.0
   GRAPH_PADDING_WIDTH = 5.0
   GRAPH_POINT_DISTANCE = 15.0
@@ -18,7 +20,7 @@ module Kuiq
     marker: [204, 203, 203],
     marker_dotted_line: [217, 217, 217],
     marker_text: [96, 96, 96],
-    selection_line: [133, 133, 133],
+    selection_stats: [133, 133, 133],
   }
   POLLING_INTERVAL_MIN = 1
   POLLING_INTERVAL_MAX = 20

--- a/lib/kuiq/model/dashboard_graph_presenter.rb
+++ b/lib/kuiq/model/dashboard_graph_presenter.rb
@@ -29,12 +29,12 @@ module Kuiq
         points = []
         return points if @stats.size <= 1
         graph_max = [job_status_max, 1].max
-        @stats.each_with_index do |job, n|
+        @stats.each_with_index do |stat, n|
           next if n == 0
-          job_status_diff_value = @stats[n-1][job_status] - job[job_status]
+          job_status_diff_value = @stats[n-1][job_status] - stat[job_status]
           x = GRAPH_WIDTH - ((n - 1) * GRAPH_POINT_DISTANCE) - GRAPH_PADDING_WIDTH
           y = ((GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) - job_status_diff_value*((GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT*2)/graph_max))
-          points << [x, y]
+          points << {x: x, y: y, time: stat[:time], job_status => job_status_diff_value}
         end
         translate_points(points)
         points
@@ -47,7 +47,7 @@ module Kuiq
         graph_max.times.map do |marker_index|
           x = GRAPH_PADDING_WIDTH
           y = GRAPH_PADDING_HEIGHT + marker_index * division_height
-          [x, y]
+          {x: x, y: y}
         end
       end
       
@@ -76,7 +76,7 @@ module Kuiq
       end
       
       def now
-        Time.now.utc.strftime("%H:%M:%S UTC")
+        Time.now.utc.strftime('%a %d %b %Y %T GMT')
       end
     end
   end


### PR DESCRIPTION
Hovering over dashboard graph now displays time/failed/processed stats. 

![kuiq-dashboard-graph-hover-stats](https://github.com/mperham/kuiq/assets/23052/0a73d856-a89b-453e-bb95-c4dde8e41182)

Also I made the graph markers on the left side auto-adjust by rendering less numbers when going over 30 processed/failed values to avoid having the marker numbers get squeezed and become unreadable. I even tested with values over 200 and the marker numbers got automatically spaced out well enough to avoid running into each other.

<img width="900" alt="kuiq-dashboard-graph-less-markers-for-bigger-stats4" src="https://github.com/mperham/kuiq/assets/23052/1db5c1ca-864c-4d3c-af23-472559c0c3d4">


I'll work on the History graph next.