### PR TITLE
History graph one week

### DIFF
--- a/lib/kuiq.rb
+++ b/lib/kuiq.rb
@@ -4,7 +4,7 @@ require "kuiq/version"
 
 module Kuiq
   WINDOW_WIDTH = 900.0
-  WINDOW_HEIGHT = 530.0
+  WINDOW_HEIGHT = 560.0
   GRAPH_WIDTH = 885.0
   GRAPH_HEIGHT = 200.0
   GRAPH_STATUS_HEIGHT = 30.0

--- a/lib/kuiq/view/dashboard.rb
+++ b/lib/kuiq/view/dashboard.rb
@@ -44,7 +44,9 @@ module Kuiq
                 }
               }
 
-              dashboard_graph(job_manager: job_manager)
+              dashboard_graph(job_manager: job_manager) {
+                stretchy false
+              }
             }
           }
 

--- a/lib/kuiq/view/dashboard_graph.rb
+++ b/lib/kuiq/view/dashboard_graph.rb
@@ -13,6 +13,7 @@ module Kuiq
       before_body do
         @presenter = Model::DashboardGraphPresenter.new(job_manager)
         @points = {}
+        @one_week_points = {}
       end
 
       after_body do
@@ -32,36 +33,62 @@ module Kuiq
           if time_remaining == 0
             presenter.record_stats
             job_manager.refresh
-            body_root.queue_redraw_all
+            @live_graph.queue_redraw_all
             time_remaining = job_manager.polling_interval
           end
         end
       end
 
       body {
-        area {
-          stretchy false
-
-          rectangle(0, 0, WINDOW_WIDTH, GRAPH_HEIGHT + GRAPH_STATUS_HEIGHT) {
-            fill 255, 255, 255
+        tab {
+          tab_item(t('LivePoll')) {
+            @live_graph = area {
+              rectangle(0, 0, WINDOW_WIDTH, GRAPH_HEIGHT + GRAPH_STATUS_HEIGHT) {
+                fill 255, 255, 255
+              }
+    
+              on_draw do
+                grid_lines
+                job_status_graph(:failed)
+                job_status_graph(:processed)
+                selection_stats
+              end
+              
+              on_mouse_moved do |event|
+                @selection_point = {x: event[:x], y: event[:y]}
+                @live_graph.queue_redraw_all
+              end
+              
+              on_mouse_exited do |outside|
+                @selection_point = nil
+                @live_graph.queue_redraw_all
+              end
+            }
           }
-
-          on_draw do
-            grid_lines
-            job_status_graph(:failed)
-            job_status_graph(:processed)
-            selection_stats
-          end
-          
-          on_mouse_moved do |event|
-            @selection_point = {x: event[:x], y: event[:y]}
-            body_root.queue_redraw_all
-          end
-          
-          on_mouse_exited do |outside|
-            @selection_point = nil
-            body_root.queue_redraw_all
-          end
+          tab_item(t('OneWeek')) {
+            @one_week_graph = area {
+              rectangle(0, 0, WINDOW_WIDTH, GRAPH_HEIGHT + GRAPH_STATUS_HEIGHT) {
+                fill 255, 255, 255
+              }
+    
+              on_draw do
+                one_week_grid_lines
+                one_week_job_status_graph(:failed)
+                one_week_job_status_graph(:processed)
+                one_week_selection_stats
+              end
+              
+              on_mouse_moved do |event|
+                @one_week_selection_point = {x: event[:x], y: event[:y]}
+                @one_week_graph.queue_redraw_all
+              end
+              
+              on_mouse_exited do |outside|
+                @one_week_point = nil
+                @one_week_graph.queue_redraw_all
+              end
+            }
+          }
         }
       }
       
@@ -160,7 +187,7 @@ module Kuiq
               fill GRAPH_DASHBOARD_COLORS[:failed]
             }
             text(text_label_x + text_label_width + font_height + 2, text_label_y, text_label_width/3.0) {
-              string("Failed: #{closest_failed_point[:failed]}") {
+              string("#{t('Failed')}: #{closest_failed_point[:failed]}") {
                 font family: 'Arial', size: 14
                 color GRAPH_DASHBOARD_COLORS[:marker_text]
               }
@@ -169,7 +196,7 @@ module Kuiq
               fill GRAPH_DASHBOARD_COLORS[:processed]
             }
             text(text_label_x + (4.0/3.0)*text_label_width + 2*font_height + 4, text_label_y, text_label_width) {
-              string("Processed: #{closest_processed_point[:processed]}") {
+              string("#{t('Processed')}: #{closest_processed_point[:processed]}") {
                 font family: 'Arial', size: 14
                 color GRAPH_DASHBOARD_COLORS[:marker_text]
               }
@@ -177,6 +204,118 @@ module Kuiq
           end
         end
       end
+      
+      def one_week_grid_lines
+        line(GRAPH_PADDING_WIDTH, GRAPH_PADDING_HEIGHT, GRAPH_PADDING_WIDTH, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
+          stroke GRAPH_DASHBOARD_COLORS[:grid]
+        }
+        line(GRAPH_PADDING_WIDTH, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT, GRAPH_WIDTH - GRAPH_PADDING_WIDTH, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
+          stroke GRAPH_DASHBOARD_COLORS[:grid]
+        }
+        grid_marker_points = presenter.one_week_grid_marker_points
+        grid_marker_points.each_with_index do |marker_point, index|
+          grid_marker_number_value = (grid_marker_points.size - index).to_i
+          grid_marker_number = grid_marker_number_value >= 1000 ? "#{grid_marker_number_value / 1000}K" : grid_marker_number.to_s
+          thick = index != grid_marker_points.size - 1
+          mod_value = (2 * ((grid_marker_points.size / 30) + 1))
+          comparison_value = mod_value > 2 ? 0 : 1
+          if mod_value > 2
+            if grid_marker_number_value % mod_value == comparison_value
+              line(marker_point[:x], marker_point[:y], marker_point[:x] + 4, marker_point[:y]) {
+                stroke *GRAPH_DASHBOARD_COLORS[:marker], thickness: thick ? 2 : 1
+              }
+            end
+          else
+            line(marker_point[:x], marker_point[:y], marker_point[:x] + 4, marker_point[:y]) {
+              stroke *GRAPH_DASHBOARD_COLORS[:marker], thickness: thick ? 2 : 1
+            }
+          end
+          if grid_marker_number_value % mod_value == comparison_value && grid_marker_number_value != grid_marker_points.size
+            line(marker_point[:x], marker_point[:y], marker_point[:x] + GRAPH_WIDTH - GRAPH_PADDING_WIDTH, marker_point[:y]) {
+              stroke *GRAPH_DASHBOARD_COLORS[:marker_dotted_line], thickness: 1, dashes: [1, 1]
+            }
+          end
+          if grid_marker_number_value % mod_value == comparison_value
+            text(marker_point[:x] + 4 + 3, marker_point[:y] - 6, 30) {
+              string(grid_marker_number) {
+                font family: 'Arial', size: 11
+                color GRAPH_DASHBOARD_COLORS[:marker_text]
+              }
+            }
+          end
+        end
+      end
+      
+      def one_week_job_status_graph(job_status)
+        last_point = nil
+        @one_week_points[job_status] = presenter.one_week_report_points(job_status)
+        @one_week_points[job_status].each do |point|
+          if last_point
+            line(last_point[:x], last_point[:y], point[:x], point[:y]) {
+              stroke *GRAPH_DASHBOARD_COLORS[job_status], thickness: 2
+            }
+          end
+          last_point = point
+        end
+      end
+      
+      def one_week_selection_stats
+        require 'bigdecimal'
+        require 'perfect_shape/point'
+        if @one_week_selection_point
+          x = @one_week_selection_point[:x]
+          closest_processed_point = @one_week_points[:processed].min_by {|point| (point[:x] - x).abs }
+          closest_failed_point = @one_week_points[:failed][@one_week_points[:processed].index(closest_processed_point)] if closest_processed_point
+          closest_x = closest_processed_point&.[](:x)
+          closest_x_distance = PerfectShape::Point.point_distance(x.to_f, 0, closest_x.to_f, 0)
+          if closest_x_distance < presenter.one_week_graph_point_distance
+            line(closest_x, GRAPH_PADDING_HEIGHT, closest_x, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
+              stroke *GRAPH_DASHBOARD_COLORS[:selection_stats], thickness: 2
+            }
+            circle(closest_failed_point[:x], closest_failed_point[:y], 4) {
+              fill *GRAPH_DASHBOARD_COLORS[:failed]
+            }
+            circle(closest_failed_point[:x], closest_failed_point[:y], 2) {
+              fill :white
+            }
+            circle(closest_processed_point[:x], closest_processed_point[:y], 4) {
+              fill *GRAPH_DASHBOARD_COLORS[:processed]
+            }
+            circle(closest_processed_point[:x], closest_processed_point[:y], 2) {
+              fill :white
+            }
+            text_label_x = (GRAPH_WIDTH/2.0)
+            text_label_y = GRAPH_HEIGHT + GRAPH_PADDING_HEIGHT
+            text_label_width = 120
+            font_height = 14
+            text(text_label_x, text_label_y, text_label_width) {
+              string(closest_processed_point[:time]) {
+                font family: 'Arial', size: font_height
+                color GRAPH_DASHBOARD_COLORS[:marker_text]
+              }
+            }
+            square(text_label_x + text_label_width, text_label_y + 2, font_height - 2) {
+              fill GRAPH_DASHBOARD_COLORS[:failed]
+            }
+            text(text_label_x + text_label_width + font_height + 2, text_label_y, text_label_width) {
+              string("#{t('Failed')}: #{closest_failed_point[:failed]}") {
+                font family: 'Arial', size: 14
+                color GRAPH_DASHBOARD_COLORS[:marker_text]
+              }
+            }
+            square(text_label_x + 2*text_label_width + font_height + 2, text_label_y + 2, font_height - 2) {
+              fill GRAPH_DASHBOARD_COLORS[:processed]
+            }
+            text(text_label_x + 2*text_label_width + 2*font_height + 4, text_label_y, text_label_width) {
+              string("#{t('Processed')}: #{closest_processed_point[:processed]}") {
+                font family: 'Arial', size: 14
+                color GRAPH_DASHBOARD_COLORS[:marker_text]
+              }
+            }
+          end
+        end
+      end
+      
     end
   end
 end


### PR DESCRIPTION
I implemented the History graph one week view as a separate sub-tab under the Dashboard tab. I couldn't include the History graph below the Dashboard graph because of a bug in LibUI that prevents rendering 2 areas in the same screen unless separated as tabs (this restriction is not there in Glimmer DSL for SWT.. yet only LibUI). There are other options, like rendering both graphs on 1 area with the headers being painted in the area too. The idea of separating graphs as different sub-tabs seems to work well enough for now though. For the time being, I just copied and pasted the dashboard graph code. In the future, I plan to refactor and extract the common repetitive parts into a line graph component (which I will turn into a reusable Glimmer graphing Ruby gem), so please ignore the copy/paste code for now as it should go away in the near future.

![kuiq-dashboard-graph-one-week-tab2](https://github.com/mperham/kuiq/assets/23052/16cd137a-16e6-4b6c-beba-3d763474cfb4)

I will implement the History graph 3-month view next.