### PR TITLE
History graph 1-month/3-months/6-months views

### DIFF
--- a/lib/kuiq/view/dashboard.rb
+++ b/lib/kuiq/view/dashboard.rb
@@ -28,7 +28,7 @@ module Kuiq
 
                 vertical_box {
                   horizontal_box {
-                    label(t("PollingInterval")) {
+                    label("#{t("PollingInterval")}:") {
                       stretchy false
                     }
 


### PR DESCRIPTION
I added the the history graph 1-month, 3-months, and 6-months subtabs under the dashboard tab.

![kuiq-dashboard-graph-multi-day-tabs](https://github.com/mperham/kuiq/assets/23052/8b1a8316-a729-4cf0-8314-59cfdeb76718)

What remains is showing vertical lines for days under the 1-week subtab, vertical lines for weeks under the 1-month subtab, and vertical lines for months under the 3-months and 6-months subtabs.