### PR TITLE
History graph periodic lines

### DIFF
--- a/lib/kuiq.rb
+++ b/lib/kuiq.rb
@@ -20,7 +20,8 @@ module Kuiq
     marker: [204, 203, 203],
     marker_dotted_line: [217, 217, 217],
     marker_text: [96, 96, 96],
-    selection_stats: [133, 133, 133]
+    selection_stats: [133, 133, 133],
+    periodic_line: [121, 121, 121],
   }
   POLLING_INTERVAL_MIN = 1
   POLLING_INTERVAL_MAX = 20

--- a/lib/kuiq/model/dashboard_graph_presenter.rb
+++ b/lib/kuiq/model/dashboard_graph_presenter.rb
@@ -1,3 +1,5 @@
+require "date"
+
 require "kuiq/model/job_manager"
 require "kuiq/model/job"
 
@@ -17,8 +19,10 @@ module Kuiq
       end
 
       def record_stats
+        raw_time = Time.now.utc
         stat = {
-          time: now,
+          time: live_poll_time_format(raw_time),
+          raw_time: raw_time,
           processed: job_manager.processed,
           failed: job_manager.failed
         }
@@ -35,7 +39,7 @@ module Kuiq
           job_status_diff_value = @stats[n - 1][job_status] - stat[job_status]
           x = GRAPH_WIDTH - ((n - 1) * GRAPH_POINT_DISTANCE) - GRAPH_PADDING_WIDTH
           y = ((GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) - job_status_diff_value * ((GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT * 2) / graph_max))
-          points << {:x => x, :y => y, :time => stat[:time], job_status => job_status_diff_value}
+          points << {x: x, y: y, time: stat[:time], job_status => job_status_diff_value}
         end
         translate_points(points)
         points
@@ -78,7 +82,8 @@ module Kuiq
           value = stat.last
           x = GRAPH_WIDTH - (n * multi_day_graph_point_distance(day_count)) - GRAPH_PADDING_WIDTH
           y = ((GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) - value*((GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT*2)/graph_max))
-          points << {x: x, y: y, time: time, job_status => value}
+          raw_time = DateTime.strptime(time, '%Y-%m-%d').to_time
+          points << {x: x, y: y, time: time, raw_time: raw_time, job_status => value}
         end
         points
       end
@@ -115,8 +120,8 @@ module Kuiq
         end
       end
 
-      def now
-        Time.now.utc.strftime("%a %d %b %Y %T GMT")
+      def live_poll_time_format(time)
+        time.strftime("%a %d %b %Y %T GMT")
       end
     end
   end

--- a/lib/kuiq/view/dashboard_graph.rb
+++ b/lib/kuiq/view/dashboard_graph.rb
@@ -68,114 +68,26 @@ module Kuiq
           }
           
           tab_item(t('OneWeek')) {
-            day_count = 7
-            area { |graph_area|
-              rectangle(0, 0, WINDOW_WIDTH, GRAPH_HEIGHT + GRAPH_STATUS_HEIGHT) {
-                fill 255, 255, 255
-              }
-
-              on_draw do
-                multi_day_grid_lines(day_count)
-                multi_day_job_status_graph(day_count, :failed)
-                multi_day_job_status_graph(day_count, :processed)
-                multi_day_selection_stats(day_count)
-              end
-
-              on_mouse_moved do |event|
-                @multi_day_selection_point[day_count] = {x: event[:x], y: event[:y]}
-                graph_area.queue_redraw_all
-              end
-
-              on_mouse_exited do |outside|
-                @multi_day_selection_point[day_count] = nil
-                graph_area.queue_redraw_all
-              end
-            }
+            multi_day_graph_area(day_count: 7)
           }
           
           tab_item(t('OneMonth')) {
-            day_count = 30
-            area { |graph_area|
-              rectangle(0, 0, WINDOW_WIDTH, GRAPH_HEIGHT + GRAPH_STATUS_HEIGHT) {
-                fill 255, 255, 255
-              }
-    
-              on_draw do
-                multi_day_grid_lines(day_count)
-                multi_day_job_status_graph(day_count, :failed)
-                multi_day_job_status_graph(day_count, :processed)
-                multi_day_selection_stats(day_count)
-              end
-              
-              on_mouse_moved do |event|
-                @multi_day_selection_point[day_count] = {x: event[:x], y: event[:y]}
-                graph_area.queue_redraw_all
-              end
-              
-              on_mouse_exited do |outside|
-                @multi_day_selection_point[day_count] = nil
-                graph_area.queue_redraw_all
-              end
-            }
+            multi_day_graph_area(day_count: 30)
           }
           
           tab_item(t('ThreeMonths')) {
-            day_count = 90
-            area { |graph_area|
-              rectangle(0, 0, WINDOW_WIDTH, GRAPH_HEIGHT + GRAPH_STATUS_HEIGHT) {
-                fill 255, 255, 255
-              }
-    
-              on_draw do
-                multi_day_grid_lines(day_count)
-                multi_day_job_status_graph(day_count, :failed)
-                multi_day_job_status_graph(day_count, :processed)
-                multi_day_selection_stats(day_count)
-              end
-              
-              on_mouse_moved do |event|
-                @multi_day_selection_point[day_count] = {x: event[:x], y: event[:y]}
-                graph_area.queue_redraw_all
-              end
-              
-              on_mouse_exited do |outside|
-                @multi_day_selection_point[day_count] = nil
-                graph_area.queue_redraw_all
-              end
-            }
+            multi_day_graph_area(day_count: 90)
           }
           
           tab_item(t('SixMonths')) {
-            day_count = 180
-            area { |graph_area|
-              rectangle(0, 0, WINDOW_WIDTH, GRAPH_HEIGHT + GRAPH_STATUS_HEIGHT) {
-                fill 255, 255, 255
-              }
-    
-              on_draw do
-                multi_day_grid_lines(day_count)
-                multi_day_job_status_graph(day_count, :failed)
-                multi_day_job_status_graph(day_count, :processed)
-                multi_day_selection_stats(day_count)
-              end
-              
-              on_mouse_moved do |event|
-                @multi_day_selection_point[day_count] = {x: event[:x], y: event[:y]}
-                graph_area.queue_redraw_all
-              end
-              
-              on_mouse_exited do |outside|
-                @multi_day_selection_point[day_count] = nil
-                graph_area.queue_redraw_all
-              end
-            }
+            multi_day_graph_area(day_count: 180)
           }
           
         }
       }
 
       private
-
+      
       def grid_lines
         line(GRAPH_PADDING_WIDTH, GRAPH_PADDING_HEIGHT, GRAPH_PADDING_WIDTH, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
           stroke GRAPH_DASHBOARD_COLORS[:grid]
@@ -193,17 +105,17 @@ module Kuiq
           if mod_value > 2
             if grid_marker_number_value % mod_value == comparison_value
               line(marker_point[:x], marker_point[:y], marker_point[:x] + 4, marker_point[:y]) {
-                stroke(*GRAPH_DASHBOARD_COLORS[:marker], thickness: thick ? 2 : 1)
+                stroke *GRAPH_DASHBOARD_COLORS[:marker], thickness: (thick ? 2 : 1)
               }
             end
           else
             line(marker_point[:x], marker_point[:y], marker_point[:x] + 4, marker_point[:y]) {
-              stroke(*GRAPH_DASHBOARD_COLORS[:marker], thickness: thick ? 2 : 1)
+              stroke *GRAPH_DASHBOARD_COLORS[:marker], thickness: (thick ? 2 : 1)
             }
           end
           if grid_marker_number_value % mod_value == comparison_value && grid_marker_number_value != grid_marker_points.size
             line(marker_point[:x], marker_point[:y], marker_point[:x] + GRAPH_WIDTH - GRAPH_PADDING_WIDTH, marker_point[:y]) {
-              stroke(*GRAPH_DASHBOARD_COLORS[:marker_dotted_line], thickness: 1, dashes: [1, 1])
+              stroke *GRAPH_DASHBOARD_COLORS[:marker_dotted_line], thickness: 1, dashes: [1, 1]
             }
           end
           if grid_marker_number_value % mod_value == comparison_value
@@ -223,7 +135,7 @@ module Kuiq
         @points[job_status].each do |point|
           if last_point
             line(last_point[:x], last_point[:y], point[:x], point[:y]) {
-              stroke(*GRAPH_DASHBOARD_COLORS[job_status], thickness: 2)
+              stroke *GRAPH_DASHBOARD_COLORS[job_status], thickness: 2
             }
           end
           last_point = point
@@ -241,16 +153,16 @@ module Kuiq
           closest_x_distance = PerfectShape::Point.point_distance(x.to_f, 0, closest_x.to_f, 0)
           if closest_x_distance < GRAPH_POINT_DISTANCE
             line(closest_x, GRAPH_PADDING_HEIGHT, closest_x, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
-              stroke(*GRAPH_DASHBOARD_COLORS[:selection_stats], thickness: 2)
+              stroke *GRAPH_DASHBOARD_COLORS[:selection_stats]
             }
             circle(closest_failed_point[:x], closest_failed_point[:y], 4) {
-              fill(*GRAPH_DASHBOARD_COLORS[:failed])
+              fill *GRAPH_DASHBOARD_COLORS[:failed]
             }
             circle(closest_failed_point[:x], closest_failed_point[:y], 2) {
               fill :white
             }
             circle(closest_processed_point[:x], closest_processed_point[:y], 4) {
-              fill(*GRAPH_DASHBOARD_COLORS[:processed])
+              fill *GRAPH_DASHBOARD_COLORS[:processed]
             }
             circle(closest_processed_point[:x], closest_processed_point[:y], 2) {
               fill :white
@@ -287,6 +199,36 @@ module Kuiq
         end
       end
       
+      def multi_day_graph_area(day_count: 30)
+        area { |graph_area|
+          rectangle(0, 0, WINDOW_WIDTH, GRAPH_HEIGHT + GRAPH_STATUS_HEIGHT) {
+            fill 255, 255, 255
+          }
+
+          on_draw do
+            multi_day_graph(day_count)
+          end
+
+          on_mouse_moved do |event|
+            @multi_day_selection_point[day_count] = {x: event[:x], y: event[:y]}
+            graph_area.queue_redraw_all
+          end
+
+          on_mouse_exited do |outside|
+            @multi_day_selection_point[day_count] = nil
+            graph_area.queue_redraw_all
+          end
+        }
+      end
+      
+      def multi_day_graph(day_count)
+        multi_day_grid_lines(day_count)
+        multi_day_job_status_graph(day_count, :failed)
+        multi_day_job_status_graph(day_count, :processed)
+        multi_day_periodic_lines(day_count)
+        multi_day_selection_stats(day_count)
+      end
+      
       def multi_day_grid_lines(day_count)
         line(GRAPH_PADDING_WIDTH, GRAPH_PADDING_HEIGHT, GRAPH_PADDING_WIDTH, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
           stroke GRAPH_DASHBOARD_COLORS[:grid]
@@ -304,17 +246,17 @@ module Kuiq
           if mod_value > 2
             if grid_marker_number_value % mod_value == comparison_value
               line(marker_point[:x], marker_point[:y], marker_point[:x] + 4, marker_point[:y]) {
-                stroke(*GRAPH_DASHBOARD_COLORS[:marker], thickness: thick ? 2 : 1)
+                stroke *GRAPH_DASHBOARD_COLORS[:marker], thickness: (thick ? 2 : 1)
               }
             end
           else
             line(marker_point[:x], marker_point[:y], marker_point[:x] + 4, marker_point[:y]) {
-              stroke(*GRAPH_DASHBOARD_COLORS[:marker], thickness: thick ? 2 : 1)
+              stroke *GRAPH_DASHBOARD_COLORS[:marker], thickness: (thick ? 2 : 1)
             }
           end
           if grid_marker_number_value % mod_value == comparison_value && grid_marker_number_value != grid_marker_points.size
             line(marker_point[:x], marker_point[:y], marker_point[:x] + GRAPH_WIDTH - GRAPH_PADDING_WIDTH, marker_point[:y]) {
-              stroke(*GRAPH_DASHBOARD_COLORS[:marker_dotted_line], thickness: 1, dashes: [1, 1])
+              stroke *GRAPH_DASHBOARD_COLORS[:marker_dotted_line], thickness: 1, dashes: [1, 1]
             }
           end
           if grid_marker_number_value % mod_value == comparison_value
@@ -335,7 +277,7 @@ module Kuiq
         @multi_day_points[day_count][job_status].each do |point|
           if last_point
             line(last_point[:x], last_point[:y], point[:x], point[:y]) {
-              stroke(*GRAPH_DASHBOARD_COLORS[job_status], thickness: 2)
+              stroke *GRAPH_DASHBOARD_COLORS[job_status], thickness: 2
             }
           end
           last_point = point
@@ -353,16 +295,16 @@ module Kuiq
           closest_x_distance = PerfectShape::Point.point_distance(x.to_f, 0, closest_x.to_f, 0)
           if closest_x_distance < presenter.multi_day_graph_point_distance(day_count)
             line(closest_x, GRAPH_PADDING_HEIGHT, closest_x, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
-              stroke(*GRAPH_DASHBOARD_COLORS[:selection_stats], thickness: 2)
+              stroke *GRAPH_DASHBOARD_COLORS[:selection_stats]
             }
             circle(closest_failed_point[:x], closest_failed_point[:y], 4) {
-              fill(*GRAPH_DASHBOARD_COLORS[:failed])
+              fill *GRAPH_DASHBOARD_COLORS[:failed]
             }
             circle(closest_failed_point[:x], closest_failed_point[:y], 2) {
               fill :white
             }
             circle(closest_processed_point[:x], closest_processed_point[:y], 4) {
-              fill(*GRAPH_DASHBOARD_COLORS[:processed])
+              fill *GRAPH_DASHBOARD_COLORS[:processed]
             }
             circle(closest_processed_point[:x], closest_processed_point[:y], 2) {
               fill :white
@@ -398,6 +340,59 @@ module Kuiq
           end
         end
       end
+      
+      def multi_day_periodic_lines(day_count)
+        case day_count
+        when ..7
+          @multi_day_points[day_count][:processed].each do |point|
+            line(point[:x], GRAPH_PADDING_HEIGHT, point[:x], GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
+              stroke *GRAPH_DASHBOARD_COLORS[:periodic_line], thickness: 1, dashes: [1, 1]
+            }
+            day = point[:raw_time].strftime("%e")
+            font_size = 14
+            text(point[:x], GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT - font_size*1.4, font_size) {
+              string(day) {
+                font family: "Arial", size: font_size
+                color GRAPH_DASHBOARD_COLORS[:failed]
+              }
+            }
+          end
+        when ..30
+          @multi_day_points[day_count][:processed].each_with_index do |point, index|
+            day_number = index + 1
+            if day_number % 7 == 0
+              line(point[:x], GRAPH_PADDING_HEIGHT, point[:x], GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
+                stroke *GRAPH_DASHBOARD_COLORS[:periodic_line], thickness: 1, dashes: [1, 1]
+              }
+              date = point[:raw_time].strftime("%b %e")
+              font_size = 14
+              text(point[:x] + 4, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT - font_size*1.4, font_size*6) {
+                string(date) {
+                  font family: "Arial", size: font_size
+                  color GRAPH_DASHBOARD_COLORS[:failed]
+                }
+              }
+            end
+          end
+        else
+          @multi_day_points[day_count][:processed].each do |point|
+            if point[:raw_time].strftime("%d") == "01"
+              line(point[:x], GRAPH_PADDING_HEIGHT, point[:x], GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT) {
+                stroke *GRAPH_DASHBOARD_COLORS[:periodic_line], thickness: 1, dashes: [1, 1]
+              }
+              date = point[:raw_time].strftime("%b")
+              font_size = 14
+              text(point[:x] + 4, GRAPH_HEIGHT - GRAPH_PADDING_HEIGHT - font_size*1.4, font_size*6) {
+                string(date) {
+                  font family: "Arial", size: font_size
+                  color GRAPH_DASHBOARD_COLORS[:failed]
+                }
+              }
+            end
+          end
+        end
+      end
+      
     end
   end
 end


### PR DESCRIPTION
I added history graph periodic lines (days for the weeks view, weeks for the 1-month view, and months for the 3-months and 6-months views)

![kuiq-dashboard-graph-multi-day-periodic-lines](https://github.com/mperham/kuiq/assets/23052/4545b6ed-4ec8-4c94-8339-b071955aa66f)

Next, I am going to work on making all the graphs grow/shrink correctly as the app window is resized by the user.