### PR TITLE
Refactor/move plotting logic to line_graph + Fix text width for periodic lines in 1 week history graph

### DIFF
--- a/lib/kuiq/view/dashboard_graph.rb
+++ b/lib/kuiq/view/dashboard_graph.rb
@@ -23,7 +23,6 @@ module Kuiq
           on_content_size_changed do
             @live_poll_line_graph.width = @presenter.graph_width = graph_width
             @live_poll_line_graph.height = @presenter.graph_height = graph_height
-            @live_poll_line_graph.grid_marker_points = presenter.grid_marker_points
             @live_poll_line_graph.lines = report_graph_lines
           end
         }
@@ -43,7 +42,6 @@ module Kuiq
           if time_remaining == 0
             presenter.record_stats
             job_manager.refresh
-            @live_poll_line_graph.grid_marker_points = presenter.grid_marker_points
             @live_poll_line_graph.lines = report_graph_lines
             time_remaining = job_manager.polling_interval
           end
@@ -57,7 +55,7 @@ module Kuiq
               width: @presenter.graph_width,
               height: @presenter.graph_height,
               lines: report_graph_lines,
-              display_attributes_on_hover: [:time, t('Failed') => :failed, t('Processed') => :processed]
+              display_attributes_on_hover: true,
             )
           }
           
@@ -87,8 +85,7 @@ module Kuiq
           {
             name: t(job_status.capitalize),
             stroke: [*GRAPH_DASHBOARD_COLORS[job_status], thickness: 2],
-            points: presenter.report_points(job_status),
-          }
+          }.merge(presenter.report_stats(job_status))
         end
       end
       

--- a/lib/kuiq/view/dashboard_graph.rb
+++ b/lib/kuiq/view/dashboard_graph.rb
@@ -257,7 +257,7 @@ module Kuiq
             }
             day = point[:raw_time].strftime("%e")
             font_size = 14
-            text(point[:x], presenter.graph_height - GRAPH_PADDING_HEIGHT - font_size*1.4, font_size) {
+            text(point[:x], presenter.graph_height - GRAPH_PADDING_HEIGHT - font_size*1.4, font_size*2) {
               string(day) {
                 font family: "Arial", size: font_size
                 color GRAPH_DASHBOARD_COLORS[:failed]


### PR DESCRIPTION
Refactor/move plotting logic to `line_graph` + Fix text width for periodic lines in 1 week history graph.

In addition to rendering, `line_graph` now handles the plotting logic (calculation of (x, y) points based on values), so this logic got removed from the graph presenter, simplifying it. This will facilitate reuse of `line_graph` as we would not need to calculate the points in the app model/presenter anymore. The `line_graph` custom control will take care of that if we simply pass it raw values.

Next, in order to reuse `line_graph` in history graphs, I need to add support for displaying periodic lines, extracting it from the dashboard graph component.