### PR TITLE
Add Live Poll support for Busy tables (Processes & Jobs) + Add queues column to Busy processes table + Refactoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "glimmer-dsl-libui", "= 0.11.6"
-gem "glimmer-libui-cc-graphs_and_charts", "= 0.1.1"
+gem "glimmer-libui-cc-graphs_and_charts", "= 0.1.2"
 gem "sidekiq"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       rouge (>= 3.26.0, < 4.0.0)
       super_module (~> 1.4.1)
       text-table (>= 1.2.4, < 2.0.0)
-    glimmer-libui-cc-graphs_and_charts (0.1.1)
+    glimmer-libui-cc-graphs_and_charts (0.1.2)
       glimmer-dsl-libui (~> 0.11)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
@@ -107,7 +107,7 @@ GEM
       tty-cursor (~> 0.7)
       tty-screen (~> 0.8)
       wisper (~> 2.0)
-    tty-screen (0.8.1)
+    tty-screen (0.8.2)
     unicode-display_width (2.5.0)
     wisper (2.0.1)
 
@@ -119,7 +119,7 @@ PLATFORMS
 
 DEPENDENCIES
   glimmer-dsl-libui (= 0.11.6)
-  glimmer-libui-cc-graphs_and_charts (= 0.1.1)
+  glimmer-libui-cc-graphs_and_charts (= 0.1.2)
   minitest
   rake
   sidekiq

--- a/lib/kuiq/model/process.rb
+++ b/lib/kuiq/model/process.rb
@@ -12,13 +12,20 @@ module Kuiq
       def rss
         format_memory(@hash["rss"])
       end
+      
+      def queues
+        @hash["queues"].join(', ')
+      end
 
       def method_missing(attr)
         @hash[attr.to_s]
       end
 
       def respond_to_missing?(attr, include_private = false)
-        super || @hash.include?(attr.to_s)
+        # Sidekiq::Process does not provide a method for checking if an attr is supported or not,
+        # so if a method is missing, we always delegate it to an attribute on the @hash
+        # even if it ends up returning nil
+        true
       end
 
       private

--- a/lib/kuiq/model/work.rb
+++ b/lib/kuiq/model/work.rb
@@ -8,8 +8,12 @@ module Kuiq
         @job = hash
       end
 
-      def method_missing(attr)
-        @job["payload"][attr.to_s]
+      def method_missing(method_name, *args, &block)
+        if @job["payload"].include?(method_name.to_s)
+          @job["payload"][method_name.to_s]
+        else
+          super
+        end
       end
 
       def respond_to_missing?(method_name, include_private = false)

--- a/lib/kuiq/view/busy.rb
+++ b/lib/kuiq/view/busy.rb
@@ -18,6 +18,10 @@ module Kuiq
             stretchy false
           }
 
+          table_toolbar(job_manager: job_manager, include_filter: false) {
+            stretchy false
+          }
+
           group(t("Processes")) {
             margined false
 
@@ -27,6 +31,7 @@ module Kuiq
               text_column(t("RSS"))
               text_column(t("Threads"))
               text_column(t("Busy"))
+              text_column(t("Queues"))
 
               cell_rows <= [job_manager, :processes,
                 column_attributes: {
@@ -34,7 +39,8 @@ module Kuiq
                   t("Started") => :started_at,
                   t("RSS") => :rss,
                   t("Threads") => :concurrency,
-                  t("Busy") => :busy
+                  t("Busy") => :busy,
+                  t("Queues") => :queues,
                 }]
             }
           }

--- a/lib/kuiq/view/morgue.rb
+++ b/lib/kuiq/view/morgue.rb
@@ -1,4 +1,5 @@
 require "kuiq/view/stat_row"
+require "kuiq/view/table_toolbar"
 require "kuiq/view/footer"
 
 module Kuiq
@@ -14,27 +15,8 @@ module Kuiq
             stretchy false
           }
           
-          horizontal_box {
+          table_toolbar(job_manager: job_manager, filter_name: "dead") {
             stretchy false
-            
-            checkbox(t('LivePoll')) {
-              stretchy false
-              
-              checked <=> [job_manager, :live_poll]
-            }
-            
-            # filler
-            label
-            
-            label("#{t('Filter')}:") {
-              stretchy false
-            }
-            
-            entry {
-              stretchy false
-              
-              text <=> [job_manager, :dead_filter]
-            }
           }
 
           table {

--- a/lib/kuiq/view/retries.rb
+++ b/lib/kuiq/view/retries.rb
@@ -1,4 +1,5 @@
 require "kuiq/view/stat_row"
+require "kuiq/view/table_toolbar"
 require "kuiq/view/footer"
 
 module Kuiq
@@ -14,27 +15,8 @@ module Kuiq
             stretchy false
           }
           
-          horizontal_box {
+          table_toolbar(job_manager: job_manager, filter_name: "retry") {
             stretchy false
-            
-            checkbox(t('LivePoll')) {
-              stretchy false
-              
-              checked <=> [job_manager, :live_poll]
-            }
-            
-            # filler
-            label
-            
-            label("#{t('Filter')}:") {
-              stretchy false
-            }
-            
-            entry {
-              stretchy false
-              
-              text <=> [job_manager, :retry_filter]
-            }
           }
 
           table {

--- a/lib/kuiq/view/scheduled.rb
+++ b/lib/kuiq/view/scheduled.rb
@@ -1,4 +1,5 @@
 require "kuiq/view/stat_row"
+require "kuiq/view/table_toolbar"
 require "kuiq/view/footer"
 
 module Kuiq
@@ -14,27 +15,8 @@ module Kuiq
             stretchy false
           }
           
-          horizontal_box {
+          table_toolbar(job_manager: job_manager, filter_name: "schedule") {
             stretchy false
-            
-            checkbox(t('LivePoll')) {
-              stretchy false
-              
-              checked <=> [job_manager, :live_poll]
-            }
-            
-            # filler
-            label
-            
-            label("#{t('Filter')}:") {
-              stretchy false
-            }
-            
-            entry {
-              stretchy false
-              
-              text <=> [job_manager, :schedule_filter]
-            }
           }
 
           table {

--- a/lib/kuiq/view/table_toolbar.rb
+++ b/lib/kuiq/view/table_toolbar.rb
@@ -1,0 +1,34 @@
+module Kuiq
+  module View
+    class TableToolbar
+      include Glimmer::LibUI::CustomControl
+  
+      option :job_manager
+      option :filter_name
+  
+      body {
+        horizontal_box {
+          checkbox(t('LivePoll')) {
+            stretchy false
+            
+            checked <=> [job_manager, :live_poll]
+          }
+          
+          # filler
+          label
+          
+          label("#{t('Filter')}:") {
+            stretchy false
+          }
+          
+          entry {
+            stretchy false
+            
+            text <=> [job_manager, "#{filter_name}_filter"]
+          }
+        }
+      }
+  
+    end
+  end
+end

--- a/lib/kuiq/view/table_toolbar.rb
+++ b/lib/kuiq/view/table_toolbar.rb
@@ -4,6 +4,7 @@ module Kuiq
       include Glimmer::LibUI::CustomControl
   
       option :job_manager
+      option :include_filter, default: true
       option :filter_name
   
       body {
@@ -17,15 +18,17 @@ module Kuiq
           # filler
           label
           
-          label("#{t('Filter')}:") {
-            stretchy false
-          }
-          
-          entry {
-            stretchy false
+          if include_filter
+            label("#{t('Filter')}:") {
+              stretchy false
+            }
             
-            text <=> [job_manager, "#{filter_name}_filter"]
-          }
+            entry {
+              stretchy false
+              
+              text <=> [job_manager, "#{filter_name}_filter"]
+            }
+          end
         }
       }
   


### PR DESCRIPTION
Work done in PR:
- Add Live Poll support for Busy tables (Processes & Jobs) 
- Add queues column to Busy Processes table 
- Refactoring (including extraction of `table_toolbar` custom control)

After I added Live Poll support to the Jobs table (data-bound to `works` method on `JobManager`), I noticed that after 
a refresh happens while I have Sidekiq jobs running in my Rails app, I could see them in the Sidekiq Web UI, but I could not see them in the desktop GUI. I printed the `work_set.size`, and it would print `20`, but then when I called `to_a` on it, it returned an empty `Array`. 

Do you know why? I tried to copy code from the Sidekiq Web UI that is using a `Paginator#page_items` method, but it still gave me an empty `Array`. Is there a special trick to force out objects or something? Could this be related to the fact that I have `sidekiq` gem version 6.5.8 running in my Rails application? My `sidekiq-ent` gem version is 2.5.3 and my `sidekiq-pro` gem version is 5.5.8.