### PR TITLE
Display Busy tab job data correctly + Support job table queue filter combo box + Refactoring

### DIFF
--- a/lib/kuiq/model/job_manager.rb
+++ b/lib/kuiq/model/job_manager.rb
@@ -12,7 +12,9 @@ module Kuiq
       BUSY_PROPERTIES = %i[process_size total_concurrency busy utilization total_rss]
 
       attr_accessor :polling_interval, :live_poll
-      attr_reader :redis_url, :redis_info, :current_time, :retry_filter, :schedule_filter, :dead_filter
+      attr_reader :redis_url, :redis_info, :current_time,
+                  :retry_filter, :schedule_filter, :dead_filter,
+                  :work_queue_filter
 
       def initialize
         @polling_interval = POLLING_INTERVAL_DEFAULT
@@ -58,7 +60,14 @@ module Kuiq
       end
 
       def works
-        work_set.to_a.map { |args| Work.new(*args) }
+        work_objects = work_set.to_a.map { |args| Work.new(*args) }
+        work_objects = work_objects.select { |work| work.queue == work_queue_filter } if !work_queue_filter.to_s.strip.empty?
+        work_objects
+      end
+      
+      def work_queue_filter=(string)
+        @work_queue_filter = string
+        notify_observers(:works)
       end
 
       def queues

--- a/lib/kuiq/model/job_manager.rb
+++ b/lib/kuiq/model/job_manager.rb
@@ -58,7 +58,7 @@ module Kuiq
       end
 
       def works
-        work_set.to_a.map { |*args| Work.new(*args) }
+        work_set.to_a.map { |args| Work.new(*args) }
       end
 
       def queues

--- a/lib/kuiq/model/work.rb
+++ b/lib/kuiq/model/work.rb
@@ -1,27 +1,38 @@
+require 'json'
+
 module Kuiq
   module Model
     class Work
-      attr_reader :process, :thread, :job
+      attr_reader :process, :thread, :job, :payload
       def initialize(process, thread, hash)
         @process = process
         @thread = thread
         @job = hash
+        @payload = JSON.parse(@job["payload"])
+      end
+      
+      def queue
+        job["queue"]
+      end
+      
+      def started_at
+        Time.at(job["run_at"]).utc.iso8601
+      end
+      
+      def job_class
+        payload["class"]
       end
 
       def method_missing(method_name, *args, &block)
-        if @job["payload"].include?(method_name.to_s)
-          @job["payload"][method_name.to_s]
+        if payload.include?(method_name.to_s)
+          payload[method_name.to_s]
         else
           super
         end
       end
 
       def respond_to_missing?(method_name, include_private = false)
-        super || @job["payload"].include?(method_name.to_s)
-      end
-
-      def started_at
-        Time.at(job["run_at"])
+        super || payload.include?(method_name.to_s)
       end
     end
   end

--- a/lib/kuiq/view/busy.rb
+++ b/lib/kuiq/view/busy.rb
@@ -44,6 +44,24 @@ module Kuiq
                 }]
             }
           }
+          
+          horizontal_box {
+            stretchy false
+            
+            # filler
+            label
+            
+            label("#{t("Queue")}:") {
+              stretchy false
+            }
+          
+            combobox {
+              stretchy false
+              
+              items [''] + job_manager.queues.map(&:name)
+              selected_item <=> [job_manager, :work_queue_filter]
+            }
+          }
 
           group(t("Jobs")) {
             margined false

--- a/lib/kuiq/view/busy.rb
+++ b/lib/kuiq/view/busy.rb
@@ -50,22 +50,22 @@ module Kuiq
 
             table {
               text_column(t("Process"))
+              text_column(t("Started"))
               text_column(t("TID"))
               text_column(t("JID"))
               text_column(t("Queue"))
               text_column(t("Job"))
               text_column(t("Arguments"))
-              text_column(t("Started"))
 
               cell_rows <= [job_manager, :works,
                 column_attributes: {
                   t("Process") => :process,
+                  t("Started") => :started_at,
                   t("TID") => :thread,
                   t("JID") => :jid,
                   t("Queue") => :queue,
-                  t("Job") => :class,
+                  t("Job") => :job_class,
                   t("Arguments") => :args,
-                  t("Started") => :started_at
                 }]
             }
           }


### PR DESCRIPTION
I finished the following items:
- Fix issue with loading arguments into Work objects
- Display Busy tab job data correctly
- Support job table queue filter combo box (dropdown)

![Screenshot 2023-12-18 at 9 00 28 PM](https://github.com/mperham/kuiq/assets/23052/923506e0-1f63-44e0-86a6-a7c0b62f611d)

I made the Busy tab Jobs table filterable by queue (using drop down right above table to the right) in order to provide the ability to view jobs per queue, which is available differently in the web interface through clicking a queue. Here, there is no need to click on the queue, the user can just select a queue from the dropdown of queues, and the job table gets filtered in the same screen.

