### PR TITLE
Fix Metrics graph by upgrading to glimmer-libui-cc-graphs_and_charts gem version 0.1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "glimmer-dsl-libui", "= 0.11.7"
-gem "glimmer-libui-cc-graphs_and_charts", "= 0.1.5"
+gem "glimmer-libui-cc-graphs_and_charts", "= 0.1.6"
 gem "sidekiq"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       rouge (>= 3.26.0, < 4.0.0)
       super_module (~> 1.4.1)
       text-table (>= 1.2.4, < 2.0.0)
-    glimmer-libui-cc-graphs_and_charts (0.1.5)
+    glimmer-libui-cc-graphs_and_charts (0.1.6)
       glimmer-dsl-libui (~> 0.11)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
@@ -119,7 +119,7 @@ PLATFORMS
 
 DEPENDENCIES
   glimmer-dsl-libui (= 0.11.7)
-  glimmer-libui-cc-graphs_and_charts (= 0.1.5)
+  glimmer-libui-cc-graphs_and_charts (= 0.1.6)
   minitest
   rake
   sidekiq

--- a/lib/kuiq.rb
+++ b/lib/kuiq.rb
@@ -5,7 +5,7 @@ require "kuiq/version"
 module Kuiq
   WINDOW_WIDTH = 1000.0
   WINDOW_HEIGHT = 635.0
-  GRAPH_MAX_POINTS_LARGEST_SCREEN = 577
+  GRAPH_MAX_POINTS_LARGEST_SCREEN = 66
   GRAPH_DASHBOARD_COLORS = {
     processed: [47, 109, 104],
     failed: [163, 40, 39],

--- a/lib/kuiq/model/metrics_graph_presenter.rb
+++ b/lib/kuiq/model/metrics_graph_presenter.rb
@@ -5,6 +5,8 @@ require "kuiq/model/job_manager"
 module Kuiq
   module Model
     class MetricsGraphPresenter
+      TIME_FORMAT = '%H:%M'
+      
       attr_reader :job_manager
       attr_accessor :graph_width, :graph_height
 
@@ -19,30 +21,16 @@ module Kuiq
       end
       
       def report_graph_line(class_metric)
-        reported_graph_lines = {
+        values = class_metric.results.series["s"].inject({}) do |output, (time, value)|
+          raw_time = DateTime.strptime(time, TIME_FORMAT).to_time
+          output.merge(raw_time => value)
+        end
+        {
           name: class_metric.name,
           stroke: [*class_metric.swatch_color, thickness: 2],
-          y_values: [],
+          values: values,
+          x_value_format: ->(raw_time) { raw_time.strftime(TIME_FORMAT) },
         }
-        series = class_metric.results.series["s"]
-        return reported_graph_lines if series.size <= 1
-        first_raw_time = first_time = nil
-        series.each_with_index do |time_value_pair, n|
-          time, value = time_value_pair
-          raw_time = DateTime.strptime(time, '%H:%M').to_time
-          if n == 0
-            first_time = time
-            first_raw_time = raw_time
-            reported_graph_lines[:x_value_start] = raw_time
-            next
-          end
-          if n == 1
-            reported_graph_lines[:x_interval_in_seconds] = first_raw_time - raw_time
-          end
-          y_value = value
-          reported_graph_lines[:y_values] << y_value
-        end
-        reported_graph_lines
       end
     end
   end

--- a/lib/kuiq/view/metrics.rb
+++ b/lib/kuiq/view/metrics.rb
@@ -43,7 +43,6 @@ module Kuiq
                 width: @presenter.graph_width,
                 height: @presenter.graph_height,
                 lines: @presenter.report_graph_lines,
-                graph_point_distance: :width_divided_by_point_count,
                 graph_point_radius: 3,
                 graph_selected_point_radius: 4,
                 graph_fill_selected_point: :line_stroke,


### PR DESCRIPTION
I fixed the Metrics graph by upgrading to glimmer-libui-cc-graphs_and_charts gem version 0.1.6, which includes support for rendering multiple line graphs without sharing the same x-axis points.

![fixed metrics graph](https://im3.ezgif.com/tmp/ezgif-3-5803a3880b.gif)

The Metrics graph auto-adjusts its horizontal scale based on all the points drawn on it. However, I still need to add auto-adjustment of scale vertically. I will work on that next. 