### PR TITLE
Upgrade to glimmer-libui-cc-graphs_and_charts 0.1.8 to fix display of grid markers in Metrics graph when max y-axis value exceeds 1 and is a non-Integer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "glimmer-dsl-libui", "= 0.11.7"
-gem "glimmer-libui-cc-graphs_and_charts", "= 0.1.7"
+gem "glimmer-libui-cc-graphs_and_charts", "= 0.1.8"
 gem "sidekiq"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       rouge (>= 3.26.0, < 4.0.0)
       super_module (~> 1.4.1)
       text-table (>= 1.2.4, < 2.0.0)
-    glimmer-libui-cc-graphs_and_charts (0.1.7)
+    glimmer-libui-cc-graphs_and_charts (0.1.8)
       glimmer-dsl-libui (~> 0.11)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
@@ -119,7 +119,7 @@ PLATFORMS
 
 DEPENDENCIES
   glimmer-dsl-libui (= 0.11.7)
-  glimmer-libui-cc-graphs_and_charts (= 0.1.7)
+  glimmer-libui-cc-graphs_and_charts (= 0.1.8)
   minitest
   rake
   sidekiq

--- a/kuiq.gemspec
+++ b/kuiq.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "glimmer-dsl-libui", "= 0.11.6"
+  spec.add_dependency "glimmer-dsl-libui", "= 0.11.7"
+  spec.add_dependency "glimmer-libui-cc-graphs_and_charts", "= 0.1.8"
   spec.add_dependency "sidekiq", "~> 7.2"
 end


### PR DESCRIPTION
Hi, I hope you had a Merry Christmas. I wish you a Happy New Year too.

I fixed an issue with the display of the grid markers for the Metrics graph when the max y-axis value exceeds 1.0

It is fixed in the Graphs and Charts gem, so we just have to upgrade it in Gemfile/gemspec, but I opened a Pull Request to share a video that demoes the vertical scaling of the Metrics graph depending on what is selected.

![kuiq-fix-metrics-graph-vertical-scaling-grid-markers](https://github.com/mperham/kuiq/assets/23052/594d98ed-24fb-46dc-b023-2007a0def5bf)
