### PR TITLE
Metrics per worker bar chart (initial implementation) + Upgrade to glimmer-libui-cc-graphs_and_charts 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "glimmer-dsl-libui", "= 0.11.7"
-gem "glimmer-libui-cc-graphs_and_charts", "= 0.1.8"
+gem "glimmer-libui-cc-graphs_and_charts", "= 0.2.1"
 gem "sidekiq"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       rouge (>= 3.26.0, < 4.0.0)
       super_module (~> 1.4.1)
       text-table (>= 1.2.4, < 2.0.0)
-    glimmer-libui-cc-graphs_and_charts (0.1.8)
+    glimmer-libui-cc-graphs_and_charts (0.2.1)
       glimmer-dsl-libui (~> 0.11)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
@@ -119,7 +119,7 @@ PLATFORMS
 
 DEPENDENCIES
   glimmer-dsl-libui (= 0.11.7)
-  glimmer-libui-cc-graphs_and_charts (= 0.1.8)
+  glimmer-libui-cc-graphs_and_charts (= 0.2.1)
   minitest
   rake
   sidekiq

--- a/kuiq.gemspec
+++ b/kuiq.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "glimmer-dsl-libui", "= 0.11.7"
-  spec.add_dependency "glimmer-libui-cc-graphs_and_charts", "= 0.1.8"
+  spec.add_dependency "glimmer-libui-cc-graphs_and_charts", "= 0.2.1"
   spec.add_dependency "sidekiq", "~> 7.2"
 end

--- a/lib/kuiq/model/metrics_graph_presenter.rb
+++ b/lib/kuiq/model/metrics_graph_presenter.rb
@@ -32,6 +32,11 @@ module Kuiq
           x_value_format: ->(raw_time) { raw_time.strftime(TIME_FORMAT) },
         }
       end
+      
+      def report_metrics_for_selected_job
+        the_metrics = job_manager.metrics_for_selected_job
+        the_metrics[:bucket_labels].zip(the_metrics[:hist_totals]).to_h
+      end
     end
   end
 end

--- a/lib/kuiq/view/dashboard_graph.rb
+++ b/lib/kuiq/view/dashboard_graph.rb
@@ -95,7 +95,7 @@ module Kuiq
       
       def graph_height
         current_window_height = body_root&.window_proxy&.content_size&.last || WINDOW_HEIGHT
-        current_window_height - 360
+        current_window_height - 395
       end
       
       def report_graph_lines

--- a/lib/kuiq/view/metrics.rb
+++ b/lib/kuiq/view/metrics.rb
@@ -1,3 +1,6 @@
+require "glimmer/view/line_graph"
+require "glimmer/view/bar_chart"
+
 require "kuiq/model/metrics_graph_presenter"
 
 require "kuiq/view/stat_row"
@@ -27,6 +30,10 @@ module Kuiq
             @metrics_line_graph.lines = @presenter.report_graph_lines
           end
         end
+        
+        observe(job_manager, :selected_job_for_metrics) do
+          @metrics_for_job_bar_chart.values = @presenter.report_metrics_for_selected_job
+        end
       end
 
       body {
@@ -38,36 +45,60 @@ module Kuiq
           group(t("Metrics")) {
             margined false
             
-            vertical_box {
-              @metrics_line_graph = line_graph(
-                width: @presenter.graph_width,
-                height: @presenter.graph_height,
-                lines: @presenter.report_graph_lines,
-                graph_point_radius: 3,
-                graph_selected_point_radius: 4,
-                graph_fill_selected_point: :line_stroke,
-              )
-  
-              table {
-                checkbox_text_color_column(t("Name")) {
-                  editable_checkbox true
+            tab {
+              tab_item('All Workers') {
+                vertical_box {
+                  @metrics_line_graph = line_graph(
+                    width: @presenter.graph_width,
+                    height: @presenter.graph_height,
+                    lines: @presenter.report_graph_lines,
+                    graph_point_radius: 3,
+                    graph_selected_point_radius: 4,
+                    graph_fill_selected_point: :line_stroke,
+                  )
+      
+                  table {
+                    checkbox_text_color_column(t("Name")) {
+                      editable_checkbox true
+                    }
+                    text_column(t("Success"))
+                    text_column(t("Failure"))
+                    text_column(t("TotalExecutionTime"))
+                    text_column(t("AvgExecutionTime"))
+      
+                    cell_rows <= [job_manager, :metrics,
+                      column_attributes: {
+                        t("Name") => :swatch_name_color,
+                        t("Success") => :success,
+                        t("Failure") => :failure,
+                        t("TotalExecutionTime") => :tet,
+                        t("AvgExecutionTime") => :aet,
+                      }]
+                  }
                 }
-                text_column(t("Success"))
-                text_column(t("Failure"))
-                text_column(t("TotalExecutionTime"))
-                text_column(t("AvgExecutionTime"))
-  
-                cell_rows <= [job_manager, :metrics,
-                  column_attributes: {
-                    t("Name") => :swatch_name_color,
-                    t("Success") => :success,
-                    t("Failure") => :failure,
-                    t("TotalExecutionTime") => :tet,
-                    t("AvgExecutionTime") => :aet,
-                  }]
+              }
+              
+              tab_item('Specific Worker') {
+                vertical_box {
+                  horizontal_box {
+                    stretchy false
+                    
+                    combobox {
+                      stretchy false
+                      
+                      items <= [job_manager, :metric_jobs, computed_by: :metrics]
+                      selected_item <=> [job_manager, :selected_job_for_metrics]
+                    }
+                  }
+                  
+                  @metrics_for_job_bar_chart = bar_chart(
+                    width: @presenter.graph_width,
+                    height: @presenter.graph_height,
+                    values: @presenter.report_metrics_for_selected_job,
+                  )
+                }
               }
             }
-            
           }
 
           horizontal_separator {
@@ -87,7 +118,7 @@ module Kuiq
       
       def graph_height
         current_window_height = body_root&.window_proxy&.content_size&.last || WINDOW_HEIGHT
-        (current_window_height - 160)/2.0 - 5
+        (current_window_height - 195)/2.0 - 5
       end
       
     end


### PR DESCRIPTION
I started implementing the Metrics per worker bar chart view. I came up with a different design for it in the desktop app just to account for the limitation in not being able to display multiple areas on the screen at the same time. I nested tabs under `Metrics` for All Workers or a Specific Worker. Also, I upgraded to glimmer-libui-cc-graphs_and_charts 0.2.1 to use the new `bar_chart` custom control. It does not display the x-axis values yet, so I will be working on that next.

![kuiq-fix-metrics-for-job-iteration1](https://github.com/mperham/kuiq/assets/23052/510d9828-28d8-4ab4-8974-10e304bd6e93)

