### PR TITLE
Upgrade to glimmer-libui-cc-graphs_and_charts 0.2.2 + Metrics for Job Bar Chart fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "glimmer-dsl-libui", "= 0.11.7"
-gem "glimmer-libui-cc-graphs_and_charts", "= 0.2.1"
+gem "glimmer-dsl-libui", "= 0.11.8"
+gem "glimmer-libui-cc-graphs_and_charts", "= 0.2.2"
 gem "sidekiq"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,11 +13,11 @@ GEM
     glimmer (2.7.4)
       array_include_methods (~> 1.4.0)
       facets (>= 3.1.0, < 4.0.0)
-    glimmer-dsl-libui (0.11.7)
+    glimmer-dsl-libui (0.11.8)
       chunky_png (~> 1.4.0)
       color (~> 1.8)
       equalizer (= 0.0.11)
-      glimmer (~> 2.7.3)
+      glimmer (~> 2.7.4)
       libui (= 0.1.2.pre)
       os (>= 1.0.0, < 2.0.0)
       perfect-shape (~> 1.0.8)
@@ -27,8 +27,8 @@ GEM
       rouge (>= 3.26.0, < 4.0.0)
       super_module (~> 1.4.1)
       text-table (>= 1.2.4, < 2.0.0)
-    glimmer-libui-cc-graphs_and_charts (0.2.1)
-      glimmer-dsl-libui (~> 0.11)
+    glimmer-libui-cc-graphs_and_charts (0.2.2)
+      glimmer-dsl-libui (>= 0.11.8, < 2.0.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     libui (0.1.2.pre)
@@ -118,8 +118,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  glimmer-dsl-libui (= 0.11.7)
-  glimmer-libui-cc-graphs_and_charts (= 0.2.1)
+  glimmer-dsl-libui (= 0.11.8)
+  glimmer-libui-cc-graphs_and_charts (= 0.2.2)
   minitest
   rake
   sidekiq

--- a/lib/kuiq/model/job_manager.rb
+++ b/lib/kuiq/model/job_manager.rb
@@ -111,7 +111,9 @@ module Kuiq
       end
       
       def metric_jobs
-        @metric_jobs ||= metrics.map(&:name)
+        @metric_jobs ||= metrics.map(&:name).yield_self do |names|
+          names.empty? ? [''] : names
+        end
       end
       
       def retried_jobs

--- a/lib/kuiq/view/metrics.rb
+++ b/lib/kuiq/view/metrics.rb
@@ -20,8 +20,8 @@ module Kuiq
       after_body do
         body_root.window_proxy.content {
           on_content_size_changed do
-            @metrics_line_graph.width = @presenter.graph_width = graph_width
-            @metrics_line_graph.height = @presenter.graph_height = graph_height
+            @metrics_for_job_bar_chart.width = @metrics_line_graph.width = @presenter.graph_width = graph_width
+            @metrics_for_job_bar_chart.height = @metrics_line_graph.height = @presenter.graph_height = graph_height
           end
         }
         
@@ -94,8 +94,13 @@ module Kuiq
                   @metrics_for_job_bar_chart = bar_chart(
                     width: @presenter.graph_width,
                     height: @presenter.graph_height,
+                    x_axis_label: "Execution Time",
+                    y_axis_label: "Jobs",
                     values: @presenter.report_metrics_for_selected_job,
                   )
+                  
+                  # filler to be replaced by bubble chart in the future
+                  area
                 }
               }
             }
@@ -118,7 +123,7 @@ module Kuiq
       
       def graph_height
         current_window_height = body_root&.window_proxy&.content_size&.last || WINDOW_HEIGHT
-        (current_window_height - 195)/2.0 - 5
+        (current_window_height - 220)/2.0 - 5
       end
       
     end


### PR DESCRIPTION
I implemented these items:
- Upgrade to glimmer-libui-cc-graphs_and_charts 0.2.2 to display x-axis values and x-axis/y-axis labels
- Ensure Metrics for Job Bar Chart scales vertically and horizontally on window resize 
- Handle case of no data for Metrics per Job to prevent crash

![Screenshot 2023-12-31 at 9 27 26 PM](https://github.com/mperham/kuiq/assets/23052/a4aea518-8cb0-46be-bf85-3227eb53c10c)

The bar chart is intentionally taking up half the available vertical space because the remaining space will get used to display the bubble chart. Once it is added, the window default height will likely get increased to make the information easier to see by the user.

One thing that remains in the Bar Chart is showing less x-axis grid markers when the window is shrunk enough to have the markers run into each other. This is already supported in the y-axis, so the same will be done for the x-axis.