### PR TITLE
Upgrade to glimmer-libui-cc-graphs_and_charts 0.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "glimmer-dsl-libui", "= 0.11.8"
-gem "glimmer-libui-cc-graphs_and_charts", "= 0.2.2"
+gem "glimmer-libui-cc-graphs_and_charts", "= 0.2.3"
 gem "sidekiq"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       rouge (>= 3.26.0, < 4.0.0)
       super_module (~> 1.4.1)
       text-table (>= 1.2.4, < 2.0.0)
-    glimmer-libui-cc-graphs_and_charts (0.2.2)
+    glimmer-libui-cc-graphs_and_charts (0.2.3)
       glimmer-dsl-libui (>= 0.11.8, < 2.0.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
@@ -119,7 +119,7 @@ PLATFORMS
 
 DEPENDENCIES
   glimmer-dsl-libui (= 0.11.8)
-  glimmer-libui-cc-graphs_and_charts (= 0.2.2)
+  glimmer-libui-cc-graphs_and_charts (= 0.2.3)
   minitest
   rake
   sidekiq

--- a/kuiq.gemspec
+++ b/kuiq.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "glimmer-dsl-libui", "= 0.11.7"
-  spec.add_dependency "glimmer-libui-cc-graphs_and_charts", "= 0.2.1"
+  spec.add_dependency "glimmer-libui-cc-graphs_and_charts", "= 0.2.3"
   spec.add_dependency "sidekiq", "~> 7.2"
 end


### PR DESCRIPTION
I upgraded to glimmer-libui-cc-graphs_and_charts 0.2.3 because it supports auto-scaling bar chart count of visible x-axis grid markers so that the grid markers would not run into each other when the graph width is shrunk or cannot fit them all

![kuiq-fix-metrics-for-job-bar-chart-horizontal-grid-marker-count-scaling](https://github.com/mperham/kuiq/assets/23052/93396bd8-5e02-497e-87fb-a9b3e17a1c9f)

Next, I will start work on the Metrics for Job Bubble Chart.